### PR TITLE
Added network_interface config option.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5,3 +5,15 @@ options:
         description: |
             URL used to fetch resources (e.g., Kafka binaries) instead of the
             location specified in resources.yaml.
+    network_interface:
+        type: string
+        default: ''
+        description: |
+            A string containing the name of a network interface, or a
+            CIDR range. For split network environments, or for other
+            secure environments, you may wish to bind to a specific
+            network interface. You may either name the interface here,
+            or specify a CIDR range that contains the IP of the
+            network interface. The charm will translate that into a
+            specific IP address to bind to, and drop that into the
+            Kafka config. To reset the bindings, pass in 0.0.0.0.

--- a/lib/charms/layer/apache_kafka.py
+++ b/lib/charms/layer/apache_kafka.py
@@ -177,21 +177,23 @@ class Kafka(object):
         if is_cidr:
             interfaces = netifaces.interfaces()
             for interface in interfaces:
-                try:
-                    ip = netifaces.ifaddresses(interface)[2][0]['addr']
-                except KeyError:
-                    continue
+                for ip_version in netifaces.AF_INET, netifaces.AF_INET6:
+                    try:
+                        ip = netifaces.ifaddresses(
+                            interface)[ip_version][0]['addr']
+                    except KeyError:
+                        continue
 
-                if ipaddress.ip_address(ip) in ipaddress.ip_network(
-                        network_interface):
-                    return ip
+                    if ipaddress.ip_address(ip) in ipaddress.ip_network(
+                            network_interface):
+                        return ip
 
             raise KafkaException(
                 u"This machine has no interfaces in CIDR range {}".format(
                     network_interface))
         else:
             try:
-                ip = netifaces.ifaddresses(network_interface)[2][0]['addr']
+                ip = netifaces.ifaddresses(network_interface)[netifaces.AF_INET][0]['addr']
             except ValueError:
                 raise KafkaException(
                     u"This machine does not have an interface '{}'".format(

--- a/reactive/kafka.py
+++ b/reactive/kafka.py
@@ -33,15 +33,19 @@ def configure_kafka(zk):
     hookenv.status_set('maintenance', 'Setting up Kafka')
     kafka = Kafka()
     zks = zk.zookeepers()
-    kafka.configure_kafka(zks)
+    network_interface = hookenv.config().get('network_interface')
+
+    kafka.configure_kafka(zks, network_interface)
     kafka.start()
     set_state('kafka.started')
     hookenv.status_set('active', 'Ready')
 
 
 @when('kafka.started', 'zookeeper.ready')
-def configure_kafka_zookeepers(zk):
+def update_config(zk):
     """Configure ready zookeepers and restart kafka if needed.
+
+    Also restart if network_interface has changed.
 
     As zks come and go, server.properties will be updated. When that file
     changes, restart Kafka and set appropriate status messages.
@@ -49,7 +53,8 @@ def configure_kafka_zookeepers(zk):
     hookenv.log('Checking Zookeeper configuration')
     kafka = Kafka()
     zks = zk.zookeepers()
-    kafka.configure_kafka(zks)
+    network_interface = hookenv.config().get('network_interface')
+    kafka.configure_kafka(zks, network_interface)
 
     server_cfg = DistConfig().path('kafka_conf') / 'server.properties'
     if any_file_changed([server_cfg]):

--- a/tests/01-deploy.py
+++ b/tests/01-deploy.py
@@ -2,6 +2,7 @@
 
 import unittest
 import amulet
+import re
 
 
 class TestDeploy(unittest.TestCase):
@@ -26,6 +27,45 @@ class TestDeploy(unittest.TestCase):
     def test_deploy(self):
         output, retcode = self.unit.run("pgrep -a java")
         assert 'Kafka' in output, "Kafka daemon is not started"
+
+    def test_bind_network_interface(self):
+        '''
+        Test to verify that we can bind to a specific network interface.
+
+        '''
+        self.d.log.debug("Binding Kafka to eth0")
+        self.d.configure('kafka', {'network_interface': 'eth0'})
+        self.d.sentry.wait_for_messages({'kafka': 'Server config changed: restarting Kafka'}, timeout=60)
+        self.d.sentry.wait_for_messages({'kafka': 'Ready'}, timeout=600)
+
+        self.d.log.debug("Checking kafka bindings ...")
+        ret = self.unit.run(
+            'grep host.name /etc/kafka/conf/server.properties')[0]
+        # Correct line should start with host.name (no comment hash
+        # mark), followed by an equals sign and something that looks
+        # like an IP address (we aren't too strict about it being a
+        # valid ip address.)
+        matcher = re.compile("^host\.name=\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}.*")
+
+        self.assertTrue('host.name' in ret)
+        self.assertTrue(matcher.match(ret))
+
+    def test_reset_network_interface(self):
+        """
+        Verify that we can reset the charm to listen on any network interface.
+
+        """
+        self.d.log.debug("Binding Kafka to 0.0.0.0")
+        self.d.configure('kafka', {'network_interface': '0.0.0.0'})
+        self.d.sentry.wait_for_messages({'kafka': 'Server config changed: restarting Kafka'}, timeout=60)
+        self.d.sentry.wait_for_messages({'kafka': 'Ready'}, timeout=600)
+
+        self.d.log.debug("Checking reset bindings ...")
+        ret = self.unit.run(
+            'grep host.name /etc/kafka/conf/server.properties')[0]
+
+        matcher = re.compile("^host\.name=0\.0\.0\.0.*")
+        self.assertTrue(matcher.match(ret))
 
 
 if __name__ == '__main__':

--- a/tests/01-deploy.py
+++ b/tests/01-deploy.py
@@ -35,8 +35,13 @@ class TestDeploy(unittest.TestCase):
         '''
         self.d.log.debug("Binding Kafka to eth0")
         self.d.configure('kafka', {'network_interface': 'eth0'})
-        self.d.sentry.wait_for_messages({'kafka': 'Server config changed: restarting Kafka'}, timeout=60)
-        self.d.sentry.wait_for_messages({'kafka': 'Ready'}, timeout=600)
+        try:
+            self.d.sentry.wait_for_messages({'kafka': 'Server config changed: restarting Kafka'}, timeout=60)
+            self.d.sentry.wait_for_messages({'kafka': 'Ready'}, timeout=600)
+        except amulet.TimeoutError:
+            # We may have just missed the message. Check to see if
+            # things worked.
+            pass
 
         self.d.log.debug("Checking kafka bindings ...")
         ret = self.unit.run(
@@ -57,8 +62,13 @@ class TestDeploy(unittest.TestCase):
         """
         self.d.log.debug("Binding Kafka to 0.0.0.0")
         self.d.configure('kafka', {'network_interface': '0.0.0.0'})
-        self.d.sentry.wait_for_messages({'kafka': 'Server config changed: restarting Kafka'}, timeout=60)
-        self.d.sentry.wait_for_messages({'kafka': 'Ready'}, timeout=600)
+        try:
+            self.d.sentry.wait_for_messages({'kafka': 'Server config changed: restarting Kafka'}, timeout=60)
+            self.d.sentry.wait_for_messages({'kafka': 'Ready'}, timeout=600)
+        except amulet.TimeoutError:
+            # We may have just missed the message. Check to see if
+            # things worked.
+            pass
 
         self.d.log.debug("Checking reset bindings ...")
         ret = self.unit.run(

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,3 +1,4 @@
 jujubigdata>=6.0.0,<7.0.0
 jujuresources>=0.3.3,<1.0.0
+netifaces==0.10.4
 


### PR DESCRIPTION
Allows an operator to bind kafka to listen on a specific network
interface. This addresses scenarios where one might want to restrict the
interface kafka talks on for security purposes.

@juju-solutions/bigdata 
