### PR TITLE
When setting announcment IP, make sure it's the one that we also use for binding

### DIFF
--- a/lib/charms/layer/apache_kafka.py
+++ b/lib/charms/layer/apache_kafka.py
@@ -58,7 +58,9 @@ class Kafka(object):
         # instead of our private ip so external (non-Juju) clients can connect
         # to kafka (admin will still have to expose kafka and ensure the
         # external client can resolve the short hostname to our public ip).
-        short_host = hookenv.config().get('hostname')
+        short_host = get_ip_for_interface(hookenv.config(network_interface))
+        if not short_host:
+            short_host = hookenv.config().get('hostname')
         if not short_host:
             short_host = check_output(['hostname', '-s']).decode('utf8').strip()
         kafka_port = self.dist_config.port('kafka')


### PR DESCRIPTION
Without it, we might publish an IP that is not accessible. While machine will be able to reach kafka, they will get redirected to potentially unaccessible IP.
