### PR TITLE
Removed hooks to set hostname.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -17,13 +17,3 @@ options:
             network interface. The charm will translate that into a
             specific IP address to bind to, and drop that into the
             Kafka config. To reset the bindings, pass in 0.0.0.0.
-    hostname:
-        type: string
-        default: ''
-        description: |
-            Specify the hostname that kafka will set as its advertised
-            hostname. Note that all clients connecting to kafka will
-            use this hostname. We\'ll setup a good default hostname
-            for you, based on your cloud provider\'s DNS settings. You
-            should set this manually only if you know what you\'re
-            doing!

--- a/lib/charms/layer/apache_kafka.py
+++ b/lib/charms/layer/apache_kafka.py
@@ -58,8 +58,10 @@ class Kafka(object):
         # instead of our private ip so external (non-Juju) clients can connect
         # to kafka (admin will still have to expose kafka and ensure the
         # external client can resolve the short hostname to our public ip).
-        short_host = hookenv.config().get('hostname')
-        if not short_host:
+        network_interface = hookenv.config('network_interface')
+        if network_interface:
+            short_host = get_ip_for_interface(network_interface)
+        else:
             short_host = check_output(['hostname', '-s']).decode('utf8').strip()
         kafka_port = self.dist_config.port('kafka')
         kafka_server_conf = self.dist_config.path('kafka_conf') / 'server.properties'

--- a/reactive/kafka.py
+++ b/reactive/kafka.py
@@ -77,14 +77,9 @@ def stop_kafka_waiting_for_zookeeper_ready():
 @when('client.joined', 'zookeeper.ready')
 def serve_client(client, zookeeper):
     kafka_port = DistConfig().port('kafka')
-    host = hookenv.config().get('hostname')
-    if not host:
-        # If we've attempted to bind to a spefic ip address, and we
-        # haven't set a hostname that will resolve to that ip, just
-        # send the ip address along.
-        network_interface = hookenv.config().get('network_interface')
-        if network_interface:
-            host = get_ip_for_interface(network_interface)
+    network_interface = hookenv.config().get('network_interface')
+    if network_interface:
+        host = get_ip_for_interface(network_interface)
 
     client.send_connection(kafka_port, host=host)
     client.send_zookeepers(zookeeper.zookeepers())


### PR DESCRIPTION
It wasn't handling multiple units well, and needs to be re-implemented
to handle multiple units when and if we need it.

Meanwhile, we just set the advertised hostname to match the network
interface's ip address if someone has bound to a specific interface.

@juju-solutions/bigdata 
